### PR TITLE
Fix built extension manifest for Chromium compatibility

### DIFF
--- a/.changeset/happy-bikes-train.md
+++ b/.changeset/happy-bikes-train.md
@@ -1,0 +1,5 @@
+---
+'github-to-linear': patch
+---
+
+Fix built extension manifest for Chromium browsers.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,20 +34,17 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
-      - name: Build extension
-        run: pnpm build
-
-      - name: Submit to Mozilla
+      - name: Build and submit to Mozilla
         if: matrix.command == 'Firefox'
-        run: npx web-ext-submit@7
+        run: pnpm build && npx web-ext-submit@7
         env:
           WEB_EXT_API_KEY: ${{ secrets.WEB_EXT_API_KEY }}
           WEB_EXT_API_SECRET: ${{ secrets.WEB_EXT_API_SECRET }}
 
-      - name: Submit to Google
+      - name: Build and submit to Google
         if: matrix.command == 'Chrome'
         working-directory: ${{ env.WEB_EXT_SOURCE_DIR }}
-        run: npx chrome-webstore-upload-cli@2 upload --auto-publish
+        run: pnpm build:chrome && npx chrome-webstore-upload-cli@2 upload --auto-publish
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "build": "node ./scripts/build.mjs",
+    "build:chrome": "node ./scripts/build.mjs --chromium",
     "dev": "pnpm dlx web-ext@7 run",
     "dev:chrome": "pnpm dlx web-ext@7 run --target=chromium"
   },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -1,15 +1,26 @@
 import fs from 'node:fs/promises';
 import pkg from '../package.json' assert { type: 'json' };
+import manifest from '../extension/manifest.json' assert { type: 'json' };
 
 console.log('Copying source files to dist...');
 await fs.cp('extension', 'dist', { recursive: true });
 
 console.log('Updating version number in manifest.json...');
-let manifest = await fs.readFile('dist/manifest.json', 'utf-8');
-manifest = manifest.replace(
-  '"version": "0.0.0"',
-  `"version": "${pkg.version}"`
+manifest.version = pkg.version;
+
+if (process.argv.includes('--chromium')) {
+  console.log('Updating manifest.json for Chromium compatibility...');
+  manifest.manifest_version = 3;
+  const swSource = manifest.background.scripts[0];
+  manifest.background.service_worker = swSource;
+  delete manifest.background.scripts;
+  delete manifest.options_ui.chrome_style;
+}
+
+await fs.writeFile(
+  'dist/manifest.json',
+  JSON.stringify(manifest, null, 2),
+  'utf-8'
 );
-await fs.writeFile('dist/manifest.json', manifest, 'utf-8');
 
 console.log('Done!');


### PR DESCRIPTION
Closes #8 

Adds some massaging of the `manifest.json` to update it to v3 for Chromium browsers during the build step.