### PR TITLE
Support multiple associated issues in the GH sidebar

### DIFF
--- a/.changeset/real-fans-bake.md
+++ b/.changeset/real-fans-bake.md
@@ -1,0 +1,5 @@
+---
+'github-to-linear': minor
+---
+
+Support displaying multiple linked issues in the GitHub sidebar. Collapsed by default, you can unfold this to see all Linear issues associated with the current issue/PR.

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -123,7 +123,28 @@ function injectSidebarUI(issues) {
     return;
   }
 
-  sidebar.prepend(h('div', { id }, IssueInfobox(issues[0])));
+  const [firstIssue, ...moreIssues] = issues;
+  const nMore = moreIssues.length;
+
+  sidebar.prepend(
+    h(
+      'div',
+      { id },
+      IssueInfobox(firstIssue),
+      nMore > 0
+        ? h(
+            'details',
+            {},
+            h(
+              'summary',
+              { class: 'f6 px-2 pb-1 Link--primary text-bold' },
+              `${nMore} more issue${nMore > 1 ? s : ''}`
+            ),
+            ...moreIssues.map(IssueInfobox)
+          )
+        : ''
+    )
+  );
 }
 
 /**
@@ -264,7 +285,7 @@ function IssueInfobox(linearIssue) {
 
   return h(
     'div',
-    { class: 'gh2l-issue-infobox border f6 mb-2 p-2 rounded-2' },
+    { class: 'gh2l-issue-infobox border f6 mb-1 p-2 rounded-2' },
     InfoboxHeading(linearIssue),
     h('table', {}, statusRow, priorityRow, assigneeRow),
     h('div', { class: 'border-top my-2' }),

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -165,10 +165,7 @@ function IssueInfobox(linearIssue) {
       h(
         'span',
         { class: 'gh2l-icon-text-lockup' },
-        h('span', {
-          class: `gh2l-status-indicator gh2l-status-${linearIssue.state.type}`,
-          style: `--gh2l-status-color:${linearIssue.state.color};`,
-        }),
+        StatusIcon(linearIssue.state),
         h('span', {}, linearIssue.state.name)
       )
     )
@@ -325,6 +322,17 @@ function LinearLogo(color = '#5E6AD2') {
       d: 'M1.2254 61.5228c-.2225-.9485.9075-1.5459 1.5964-.857l36.5124 36.5124c.6889.6889.0915 1.8189-.857 1.5964C20.0515 94.4522 5.5478 79.9485 1.2254 61.5228ZM.002 46.8891a.9896.9896 0 0 0 .2896.7606l52.0588 52.0588a.9887.9887 0 0 0 .7606.2896 50.0747 50.0747 0 0 0 6.9624-.9259c.7645-.157 1.0301-1.0963.4782-1.6481L2.576 39.4485c-.552-.5519-1.4912-.2863-1.6482.4782a50.0671 50.0671 0 0 0-.926 6.9624Zm4.209-17.1837c-.1665.3738-.0817.8106.2077 1.1l64.776 64.776c.2894.2894.7262.3742 1.1.2077a49.9079 49.9079 0 0 0 5.1855-2.684c.5521-.328.6373-1.0867.1832-1.5407L8.4357 24.3367c-.4541-.4541-1.2128-.3689-1.5408.1832a49.8961 49.8961 0 0 0-2.684 5.1855Zm8.4478-11.6314c-.3701-.3701-.393-.9637-.0443-1.3541C21.7795 6.4593 35.1114 0 49.9519 0 77.5927 0 100 22.4073 100 50.0481c0 14.8405-6.4593 28.1724-16.7199 37.3375-.3903.3487-.984.3258-1.3542-.0443L12.6587 18.074Z',
     })
   );
+}
+
+/**
+ * Render an issue status icon, similar to Linear’s style.
+ * @param {{ type: string; color: string }} state
+ */
+function StatusIcon({ type, color }) {
+  return h('span', {
+    class: `gh2l-status-indicator gh2l-status-${type}`,
+    style: `--gh2l-status-color:${color};`,
+  });
 }
 
 /**

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -138,7 +138,15 @@ function injectSidebarUI(issues) {
             h(
               'summary',
               { class: 'f6 px-2 pb-1 Link--primary text-bold' },
-              `${nMore} more issue${nMore > 1 ? s : ''}`
+              h(
+                'span',
+                {
+                  class: 'd-inline-flex gap-1 flex-items-center',
+                  style: 'vertical-align: middle;',
+                },
+                ...moreIssues.map((issue) => StatusIcon(issue.state)),
+                `${nMore} more issue${nMore > 1 ? s : ''}`
+              )
             ),
             ...moreIssues.map(IssueInfobox)
           )


### PR DESCRIPTION
This PR updates the extension to show if there are multiple associated Linear tickets on an issue or PR. The disclosure link also shows status icons for each additional issue so you can their status at a glance.

Here’s an example:

| collapsed | open |
|---|---|
| ![image](https://user-images.githubusercontent.com/357379/229529884-96b36056-97f1-4416-b378-be27d5a79436.png) | ![image](https://user-images.githubusercontent.com/357379/229529981-192a49b2-5aab-4340-934d-cc2baed3b562.png) |

No changes here regarding the _order_ of issues yet. The first issue will be the most recently created issue. See #12 for more thoughts.