### PR TITLE
Display issue title in sidebar cards

### DIFF
--- a/.changeset/famous-jokes-know.md
+++ b/.changeset/famous-jokes-know.md
@@ -1,0 +1,5 @@
+---
+'github-to-linear': minor
+---
+
+Display a Linear issue’s title in sidebar cards.

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -310,7 +310,12 @@ function InfoboxHeading(linearIssue) {
         class: 'Link--primary gh2l-icon-text-lockup',
       },
       LinearLogo(linearIssue.team.color),
-      h('span', { class: 'text-bold' }, linearIssue.identifier)
+      h(
+        'span',
+        { class: 'Truncate gap-1' },
+        h('span', { class: 'text-bold' }, linearIssue.identifier, ' '),
+        h('span', { class: 'Truncate-text color-fg-muted' }, linearIssue.title)
+      )
     )
   );
 }
@@ -427,6 +432,7 @@ async function getNewIssueUrl(title, description) {
  * @returns {Promise<null | Array<{
  *  url: string;
  *  identifier: string;
+ *  title: string;
  *  state: { name: string; color: string; type: string }
  *  priorityLabel: string;
  *  priority: number;
@@ -458,6 +464,7 @@ async function fetchExistingIssues(issueUrl, identifier) {
     nodes {
       url
       identifier
+      title
       state { name color type }
       priorityLabel
       priority


### PR DESCRIPTION
Adds the title of a Linear issue to sidebar cards. Particularly helpful if the associated issue was for just part of the work associated with a PR or issue, like reviewing etc.

![image](https://user-images.githubusercontent.com/357379/229535607-5f45d2b4-abc3-463f-a16f-759a2b85be71.png)

Longer titles are truncated:

![image](https://user-images.githubusercontent.com/357379/229535690-06154d0a-5219-49cd-ac66-f70c57788805.png)
