### PR TITLE
fix: show linear link on PR Commits/Check/File changed as well as Conversations

### DIFF
--- a/.changeset/wise-pumpkins-kiss.md
+++ b/.changeset/wise-pumpkins-kiss.md
@@ -1,0 +1,5 @@
+---
+"github-to-linear": patch
+---
+
+Show linear link on PR Commits/Check/File changed as well as Conversations

--- a/.changeset/wise-pumpkins-kiss.md
+++ b/.changeset/wise-pumpkins-kiss.md
@@ -2,4 +2,4 @@
 "github-to-linear": minor
 ---
 
-Show linear link on PR Commits/Check/File changed as well as Conversations
+Show Linear link on PR Commits, Checks, and Files changed tabs as well as Conversations

--- a/.changeset/wise-pumpkins-kiss.md
+++ b/.changeset/wise-pumpkins-kiss.md
@@ -1,5 +1,5 @@
 ---
-"github-to-linear": patch
+"github-to-linear": minor
 ---
 
 Show linear link on PR Commits/Check/File changed as well as Conversations

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -660,7 +660,7 @@ function cleanUrl(number) {
   const urlComponents = url.split('/')
 
   let component = urlComponents.pop()
-  while(component !== number) {
+  while(component && component !== number) {
     component = urlComponents.pop()
   }
 

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -664,7 +664,7 @@ function cleanUrl(number) {
     component = urlComponents.pop()
   }
 
-  return urlComponents.reduce((acc, curr) => acc + '/' + curr) + '/' + number
+  return urlComponents.join('/') + '/' + number;
 }
 
 /** Check if we’re on a PR tab like commits, checks, or files changed. */

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -87,10 +87,11 @@ async function injectSingleIssueUI() {
   let title = identifier;
   if (issueTitle) title += ' — ' + issueTitle;
   const typeLabel = issueMetaData.type === 'pull' ? 'PR' : 'Issue';
-  const description = `GitHub ${typeLabel}: ${cleanUrl()}`;
+  const cleanedUrl = cleanUrl(issueMetaData.number)
+  const description = `GitHub ${typeLabel}: ${cleanedUrl}`;
   const newIssueUrl = await getNewIssueUrl(title, description);
 
-  const issues = await fetchExistingIssues({ url: cleanUrl(), identifier });
+  const issues = await fetchExistingIssues({ url: cleanedUrl, identifier });
   const linearIssue = issues?.[0];
 
   const ButtonGroup = h(
@@ -647,12 +648,20 @@ async function fetchExistingIssues(currentIssue) {
   return response?.data?.issueSearch?.nodes || null;
 }
 
-/** Get the current URL without any query params or fragment hashes. */
-function cleanUrl() {
+/** Get the current base PR/Issue URL without any query params or fragment hashes. */
+function cleanUrl(number) {
   const rawUrl = new URL(window.location.href);
   rawUrl.hash = '';
   rawUrl.searchParams.forEach((_, key) => rawUrl.searchParams.delete(key));
-  return rawUrl.href;
+  const url = rawUrl.href;
+  const urlComponents = url.split('/')
+
+  let component = urlComponents.pop()
+  while(component !== number) {
+    component = urlComponents.pop()
+  }
+
+  return urlComponents.reduce((acc, curr) => acc + '/' + curr) + '/' + number
 }
 
 /** Check if we’re on a PR tab like commits, checks, or files changed. */

--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -648,7 +648,10 @@ async function fetchExistingIssues(currentIssue) {
   return response?.data?.issueSearch?.nodes || null;
 }
 
-/** Get the current base PR/Issue URL without any query params or fragment hashes. */
+/**
+ * Get the current base PR/Issue URL without any query params or fragment hashes.
+ * @param {string} number The current PR/issue number.
+ */
 function cleanUrl(number) {
   const rawUrl = new URL(window.location.href);
   rawUrl.hash = '';


### PR DESCRIPTION
Addresses issue https://github.com/delucis/github-to-linear/issues/33

### Current
Linear issue link shows on:
- `https://github.com/delucis/github-to-linear/pull/25`

But a "Add to linear" button shows on:
- `https://github.com/delucis/github-to-linear/pull/25/commits`
- `https://github.com/delucis/github-to-linear/pull/25/checks`
- `https://github.com/delucis/github-to-linear/pull/25/files`

### New
Linear issue link shows on:
- `https://github.com/delucis/github-to-linear/pull/25`
- `https://github.com/delucis/github-to-linear/pull/25/commits`
- `https://github.com/delucis/github-to-linear/pull/25/checks`
- `https://github.com/delucis/github-to-linear/pull/25/files`