### PR TITLE
Fix broken issue search for GitHub PRs

### DIFF
--- a/extension/scripts/content.js
+++ b/extension/scripts/content.js
@@ -612,7 +612,7 @@ async function fetchExistingIssues(currentIssue) {
     chrome.runtime.sendMessage(
       {
         linearQuery: `{
-  issueSearch(
+  issues(
     filter: {
       or: [
         ${issues.map(makeFilterBlock).join('\n')}
@@ -645,7 +645,7 @@ async function fetchExistingIssues(currentIssue) {
       (response) => resolve(response)
     );
   });
-  return response?.data?.issueSearch?.nodes || null;
+  return response?.data?.issues?.nodes || null;
 }
 
 /**


### PR DESCRIPTION
The extension uses the `issueSearch` root field. This field is deprecated [1] and, for me, no longer functions properly. This breaks various parts of the extension including the widget showing the associated Linear issue on PRs.

Switch the query to use a non-deprecated API, fixing the widget on PRs.

[1] https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference?query=issueSearch#issueSearch